### PR TITLE
Closes preadly/api_application#701: Fixed URL encoding.

### DIFF
--- a/lib/bulbasaur/utils/normalize_url.rb
+++ b/lib/bulbasaur/utils/normalize_url.rb
@@ -1,21 +1,15 @@
 module Bulbasaur
-
   class NormalizeURL
-
     def initialize(base_url, context_url)
       @base_url = base_url
       @context_url = context_url
     end
 
     def call
-      if @context_url =~ /^https?:\/\//
-        URI::encode @context_url
-      else
-        URI::join(@base_url, @context_url).to_s
-      end
+      url = (@context_url =~ /^https?:\/\//) ? @context_url : URI::join(@base_url, @context_url).to_s
+      URI::encode URI::decode url
     rescue
-      raise ArgumentError, "Not possible normalize url, check the params [base_url: #{@base_url}, context_url: #{@context_url}]"
+      raise ArgumentError, "Unable to normalize URL. Params: [base_url: #{@base_url}, context_url: #{@context_url}]."
     end
-
   end
 end

--- a/lib/bulbasaur/version.rb
+++ b/lib/bulbasaur/version.rb
@@ -3,7 +3,7 @@ module Bulbasaur
   module Version
     MAJOR = 0
     MINOR = 6
-    PATCH = 0
+    PATCH = 1
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
   end
   

--- a/spec/bulbasaur/utils/normalize_url_spec.rb
+++ b/spec/bulbasaur/utils/normalize_url_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe Bulbasaur::NormalizeURL do
       end
     end
 
+    context 'When using an encoded URL' do
+      let(:context_url) { 'http://www.test.com/Hello%C3%A7a_9.jpg~original' }
+
+      it 'returns the normalized URL' do
+        expect(subject).to eq 'http://www.test.com/Hello%C3%A7a_9.jpg~original'
+      end
+    end
+
     context "When use url not normalized with slash on base: hello.jpg" do
       
       let(:base_url) do


### PR DESCRIPTION
This closes preadly/api_application#701.