### PR TITLE
Fixed a bug in normalize image sources.

### DIFF
--- a/lib/bulbasaur/utils/normalize_image_sources.rb
+++ b/lib/bulbasaur/utils/normalize_image_sources.rb
@@ -28,13 +28,17 @@ module Bulbasaur
 
     def adjust(element, attr)
       element.set_attribute 'src', lazy_load_url(element, element.xpath(attr).text)
-      element.xpath(attr).remove
+      remove_target_attrs_from element
     end
 
     def lazy_load_url(element, text)
       text_match = text.match(DOMAIN_REGEX).to_s
       element_match = element.css('@src').text.match(DOMAIN_REGEX).to_s
-      (text_match == element_match) ? text : "#{element_match}/#{text}"
+      element_match.empty? || text_match == element_match ? text : "#{element_match}/#{text}"
+    end
+
+    def remove_target_attrs_from(element)
+      @target_attrs.each { |attr| element.xpath("@#{attr}").remove }
     end
   end
 end

--- a/lib/bulbasaur/version.rb
+++ b/lib/bulbasaur/version.rb
@@ -3,7 +3,7 @@ module Bulbasaur
   module Version
     MAJOR = 0
     MINOR = 8
-    PATCH = 0
+    PATCH = 1
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
   end
   

--- a/spec/bulbasaur/utils/normalize_image_sources_spec.rb
+++ b/spec/bulbasaur/utils/normalize_image_sources_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe Bulbasaur::NormalizeImageSources do
         <img src="http://somewhere.to/get/another-pixel.gif" data-image="http://somewhere.to/get/the-other-real-image.jpg">
         <img src="http://somewhere.to/get/a-third-pixel.gif" data-src="get/the-third-real-image.jpg">
         <img src="otherplace.to/load/a-fourth-pixel.gif" lazy-data="otherplace.to/load/the-fourth-real-image.jpg">
-        )
+        <img src="https://place.where/an-image/is/without-extension/" data-src="https://place.where/an-image/is/without-extension/">
+        <img src="https://place.where/an-image/has-two/lazy-params/" data-src="https://place.where/an-image/has-two/lazy-params/" data-image="https://place.where/an-image/has-two/lazy-params/">
+        <img lazy-data="https://place.where/an-image/has/no-src-tag.jpg">
+      )
     end
     
     context "When there are no target attributes" do
@@ -40,7 +43,10 @@ RSpec.describe Bulbasaur::NormalizeImageSources do
           <img src="http://somewhere.to/get/the-other-real-image.jpg">
           <img src="http://somewhere.to/get/a-third-pixel.gif" data-src="get/the-third-real-image.jpg">
           <img src="otherplace.to/load/a-fourth-pixel.gif" lazy-data="otherplace.to/load/the-fourth-real-image.jpg">
-          )
+          <img src="https://place.where/an-image/is/without-extension/" data-src="https://place.where/an-image/is/without-extension/">
+          <img src="https://place.where/an-image/has-two/lazy-params/" data-src="https://place.where/an-image/has-two/lazy-params/">
+          <img lazy-data="https://place.where/an-image/has/no-src-tag.jpg">
+        )
       end
 
       it "Returns the HTML code with the specified image tags adjusted" do
@@ -60,6 +66,9 @@ RSpec.describe Bulbasaur::NormalizeImageSources do
           <img src="http://somewhere.to/get/the-other-real-image.jpg">
           <img src="http://somewhere.to/get/the-third-real-image.jpg">
           <img src="otherplace.to/load/the-fourth-real-image.jpg">
+          <img src="https://place.where/an-image/is/without-extension/">
+          <img src="https://place.where/an-image/has-two/lazy-params/">
+          <img src="https://place.where/an-image/has/no-src-tag.jpg">
         )
       end
 


### PR DESCRIPTION
This fixes a bug in `NormalizeImageSources` where a slash is added to the beginning of the newly created `src` attribute when a image tag has no src attribute before the operation. A test for this situation was added.
